### PR TITLE
Add MCP package validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ Vous pouvez également mentionner explicitement l'outil MCP que vous souhaitez u
 
 ### Mode Yolo
 
+## Vérification des serveurs MCP
+
+Un script `validate_mcp_servers.py` est fourni pour vérifier si les paquets référencés dans les fichiers `*_mcp.json` existent sur npm. Exécutez :
+
+```
+python3 validate_mcp_servers.py
+```
+
+Le script parcourt tous les fichiers de configuration et indique `OK` si le paquet est disponible ou `MISSING` sinon.
+
+
 Pour une exécution automatique sans demande d'approbation, vous pouvez activer le "Mode Yolo" dans les paramètres de Cursor. Cela permet à l'agent d'exécuter des outils MCP sans demander votre approbation explicite pour chaque utilisation.
 
 ## Dépannage

--- a/validate_mcp_servers.py
+++ b/validate_mcp_servers.py
@@ -1,0 +1,44 @@
+import os
+import json
+import subprocess
+
+
+def package_exists(pkg_name: str) -> bool:
+    try:
+        subprocess.run([
+            'npm',
+            'view',
+            pkg_name,
+            'version'
+        ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def main():
+    root = os.path.dirname(__file__)
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            if filename.endswith('_mcp.json'):
+                full_path = os.path.join(dirpath, filename)
+                with open(full_path) as fh:
+                    try:
+                        data = json.load(fh)
+                    except json.JSONDecodeError:
+                        print(f'{full_path}: INVALID JSON')
+                        continue
+                for srv_name, srv_cfg in data.get('mcpServers', {}).items():
+                    cmd = srv_cfg.get('command')
+                    args = srv_cfg.get('args', [])
+                    pkg = None
+                    if cmd == 'npx' and args:
+                        pkg = args[-1]
+                    if pkg:
+                        exists = package_exists(pkg)
+                        status = 'OK' if exists else 'MISSING'
+                        print(f'{full_path}: {srv_name}: {pkg}: {status}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `validate_mcp_servers.py` to check that packages referenced in the JSON files are present on npm
- document this new validation step in the README

## Testing
- `python3 -m py_compile validate_mcp_servers.py`
- `python3 validate_mcp_servers.py | head -n 20`
- `python3 validate_mcp_servers.py | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6842aa1d17fc832f8a448c076ae08f2a