### PR TITLE
Add Python package checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ Vous pouvez également mentionner explicitement l'outil MCP que vous souhaitez u
 
 ### Mode Yolo
 
+## Vérification des serveurs MCP
+
+Un script `validate_mcp_servers.py` est fourni pour vérifier si les paquets référencés dans les fichiers `*_mcp.json` existent sur npm ou PyPI. Exécutez :
+
+```
+python3 validate_mcp_servers.py
+```
+
+Le script parcourt tous les fichiers de configuration et indique `OK` si le paquet est disponible ou `MISSING` sinon. Les outils basés sur `npx` sont vérifiés sur npm, tandis que ceux exécutés via `uv run python -m` sont validés sur PyPI.
+
+
 Pour une exécution automatique sans demande d'approbation, vous pouvez activer le "Mode Yolo" dans les paramètres de Cursor. Cela permet à l'agent d'exécuter des outils MCP sans demander votre approbation explicite pour chaque utilisation.
 
 ## Dépannage

--- a/validate_mcp_servers.py
+++ b/validate_mcp_servers.py
@@ -1,0 +1,65 @@
+import os
+import json
+import subprocess
+import urllib.request
+
+
+def npm_package_exists(pkg_name: str) -> bool:
+    try:
+        subprocess.run([
+            'npm',
+            'view',
+            pkg_name,
+            'version'
+        ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def pip_package_exists(pkg_name: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"https://pypi.org/pypi/{pkg_name}/json"):
+            return True
+    except Exception:
+        return False
+
+
+def main():
+    root = os.path.dirname(__file__)
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            if filename.endswith('_mcp.json'):
+                full_path = os.path.join(dirpath, filename)
+                with open(full_path) as fh:
+                    try:
+                        data = json.load(fh)
+                    except json.JSONDecodeError:
+                        print(f'{full_path}: INVALID JSON')
+                        continue
+                for srv_name, srv_cfg in data.get('mcpServers', {}).items():
+                    cmd = srv_cfg.get('command')
+                    args = srv_cfg.get('args', [])
+                    pkg = None
+                    checker = None
+
+                    if cmd == 'npx' and args:
+                        pkg = args[-1]
+                        checker = npm_package_exists
+
+                    elif cmd in {'uv', 'python'} and args:
+                        if args[:3] == ['run', 'python', '-m'] and len(args) >= 4:
+                            pkg = args[3]
+                            checker = pip_package_exists
+                        elif args and args[0] == '-m' and len(args) >= 2:
+                            pkg = args[1]
+                            checker = pip_package_exists
+
+                    if pkg and checker:
+                        exists = checker(pkg)
+                        status = 'OK' if exists else 'MISSING'
+                        print(f'{full_path}: {srv_name}: {pkg}: {status}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- extend `validate_mcp_servers.py` to detect `uv run python -m` entries and verify packages on PyPI
- document that packages are checked on npm or PyPI in README

## Testing
- `python3 -m py_compile validate_mcp_servers.py`
- `python3 validate_mcp_servers.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6842aa1d17fc832f8a448c076ae08f2a